### PR TITLE
[Fix] Bump PG version

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,7 @@ services:
       - db
 
   db:
-    image: postgres:12-alpine
+    image: postgres:16-alpine
     restart: always
     environment:
       - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
* This PR changes PG version to PG 16
* This allows use of the `createdb.sql` in the google drive w/o any changes