### PR TITLE
Support empty course search queries and allow department to be lowercase

### DIFF
--- a/core/daos/courses.py
+++ b/core/daos/courses.py
@@ -136,7 +136,7 @@ def course_search_by_filters_count(
     if count_by is not None:
         count_query = f"{count_by}, COUNT(*) as count"
         group_by = f"GROUP BY {count_by}"
-        if not all(lambda x: x is None, args.values()):
+        if not all(x is None for x in args.values()):
             not_null_clause = f" AND {count_by} IS NOT NULL"
         else:
             not_null_clause = f" WHERE {count_by} IS NOT NULL"

--- a/core/views/courses.py
+++ b/core/views/courses.py
@@ -13,25 +13,25 @@ from .utils import validate_page_limit, try_response
 
 @api_view(["GET"])
 @try_response
-def course_summary_view(request, department, course_number):
-    json_data = course_select_summary(department, course_number)
+def course_summary_view(request, department: str, course_number: str):
+    json_data = course_select_summary(department.upper(), course_number)
 
     return JsonResponse(json_data)
 
 
 @api_view(["GET"])
 @try_response
-def course_reviews_stats_view(request, department, course_number):
-    json_data = get_course_reviews_stats(department, course_number)
+def course_reviews_stats_view(request, department: str, course_number: str):
+    json_data = get_course_reviews_stats(department.upper(), course_number)
 
     return JsonResponse(json_data)
 
 
 @api_view(["GET"])
 @try_response
-def course_schedules_view(request, department, course_number):
+def course_schedules_view(request, department: str, course_number: str):
     json_data = get_paginated_schedules_by_course(
-        department,
+        department.upper(),
         course_number,
         **validate_page_limit(request),
     )
@@ -41,9 +41,9 @@ def course_schedules_view(request, department, course_number):
 
 @api_view(["GET"])
 @try_response
-def course_reviews_view(request, department, course_number):
+def course_reviews_view(request, department: str, course_number: str):
     json_data = get_paginated_reviews_by_course(
-        department,
+        department.upper(),
         course_number,
         **validate_page_limit(request),
         tags=request.GET.getlist("tags"),


### PR DESCRIPTION
* Addresses #49 
* Now, empty queries to /courses/search will not cause an error and will instead return all items (as intended)